### PR TITLE
pgvector2-vectordb-reference-phi-309

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -380,6 +380,7 @@
           "group": "VectorDbs",
           "pages": [
             "reference/blocks/vectordb/pgvector",
+            "reference/blocks/vectordb/pgvector2",
             "reference/blocks/vectordb/singlestore",
             "reference/blocks/vectordb/qdrant"
           ]

--- a/reference/blocks/vectordb/pgvector2.mdx
+++ b/reference/blocks/vectordb/pgvector2.mdx
@@ -1,5 +1,5 @@
 ---
-title: PgVector
+title: PgVector2
 ---
 
 ## PgVectorDb Reference


### PR DESCRIPTION
Removed the example, as it was not indicating the `vectordb`, but rather the docker app. 