### PR TITLE
Fixing broken links to toolkits pages

### DIFF
--- a/tools/toolkits.mdx
+++ b/tools/toolkits.mdx
@@ -7,34 +7,34 @@ A **Toolkit** is a collection of functions that can be added to an Assistant. Th
 The following **Toolkits** are available to use
 
 <CardGroup cols={2}>
-  <Card title="DuckDuckGo" icon="duck" href="/blocks/tools/duckduckgo">
+  <Card title="DuckDuckGo" icon="duck" href="/tools/duckduckgo">
     Tools to search the web using DuckDuckGo.
   </Card>
-  <Card title="Python" icon="python" href="/blocks/tools/python">
+  <Card title="Python" icon="python" href="/tools/python">
     Tools to write and run python code.
   </Card>
-  <Card title="File" icon="notes" href="/blocks/tools/file">
+  <Card title="File" icon="notes" href="/tools/file">
     Tools to read and write files.
   </Card>
-  <Card title="Shell" icon="terminal" href="/blocks/tools/shell">
+  <Card title="Shell" icon="terminal" href="/tools/shell">
     Tools to run shell commands.
   </Card>
-  <Card title="DuckDb" icon="duck" href="/blocks/tools/duckdb">
+  <Card title="DuckDb" icon="duck" href="/tools/duckdb">
     Tools to run SQL using DuckDb.
   </Card>
-  <Card title="Arxiv" icon="books" href="/blocks/tools/arxiv">
+  <Card title="Arxiv" icon="books" href="/tools/arxiv">
     Tools to read arXiv papers.
   </Card>
-  <Card title="Email" icon="envelope" href="/blocks/tools/email">
+  <Card title="Email" icon="envelope" href="/tools/email">
     Tools to send emails.
   </Card>
-  <Card title="Website" icon="globe" href="/blocks/tools/website">
+  <Card title="Website" icon="globe" href="/tools/website">
     Tools to scrape websites.
   </Card>
-  <Card title="Wikipedia" icon="book" href="/blocks/tools/wikipedia">
+  <Card title="Wikipedia" icon="book" href="/tools/wikipedia">
     Tools to search wikipedia.
   </Card>
-  <Card title="Tavily" icon="globe" href="/blocks/tools/tavily">
+  <Card title="Tavily" icon="globe" href="/tools/tavily">
     Tools to search the web using Tavily.
   </Card>
 


### PR DESCRIPTION
Addressing this issue (https://github.com/phidatahq/phidata/issues/188)