### PR TITLE
Adding Prerequisites Section

### DIFF
--- a/tools/duckdb.mdx
+++ b/tools/duckdb.mdx
@@ -4,6 +4,16 @@ title: DuckDb Tools
 
 **DuckDbTools** enable an Assistant to run SQL and analyze data using DuckDb.
 
+### Prerequisites
+The following examples require DuckDB installed.
+To install `DuckDB`:
+
+    ```shell
+    pip install duckdb --upgrade
+    ```
+
+For more installation options, please refer to [DuckDB documentation](https://duckdb.org/docs/installation). 
+
 ## Example
 
 The following assistant will analyze the movies file using SQL and return the result.


### PR DESCRIPTION
Adding Prerequisites Section to install DuckDB module first before trying to run the example, to set clear expectation and avoid user frustration