### PR TITLE
Add OpenLIT in monitoring doc

### DIFF
--- a/monitoring.mdx
+++ b/monitoring.mdx
@@ -48,3 +48,9 @@ python debugging.py
 ```
 
 <img height="200" src="/images/debugging.png" style={{ borderRadius: "8px" }} />
+
+### Monitoring with OpenLIT (OpenTelemetry)
+
+Phidata integrates with OpenLIT to deliver complete execution traces and metrics of your Agent events that can be forwarded to any OpenTelemetry-compatible backend, such as OpenLIT itself, Grafana, New Relic, and more. This integration allows you to consolidate data related to LLM usage, VectorDBs, and agent tasks into a single platform, making it easy to debut in production.
+
+To begin, follow the OpenLIT Quickstart Guide available [here](https://docs.openlit.io/latest/quickstart-observability).


### PR DESCRIPTION
Hi Team, I am one of the maintainers of [OpenLIT](https://github.com/openlit/openlit) and we support Obserability for LLM agents built using Phidata, It is all OpenTelemetry-native so the traces and metrics can be sent to any platform like [Grafana](https://grafana.com/docs/grafana-cloud/monitor-applications/ai-observability/introduction/) or any [OSS OTel tools](https://opentelemetry.io/blog/2024/llm-observability/)

Although I know Phidata automatically does show monitoring usage, OpenLIT helps when the users are using LLM + VectorDBs + agent events as the consolidated monitoring gives them a complete picture. As developers are generally already using one of the observability tool, This will also help them be able to continue using the same stack (Mkaing it easier in long term) 

Figured the mention here might be useful for developers hence adding the reference in documentation page.

I have just added a small para for now, But let me know, I can add a better detailed documentation aswell. 