### PR TITLE
slack get channel history needs channel ID, not channel name

### DIFF
--- a/tools/slack.mdx
+++ b/tools/slack.mdx
@@ -40,8 +40,8 @@ agent.print_response("Send a message 'Hello from Phi!' to the channel #general",
 # Example 2: List all channels in the Slack workspace
 agent.print_response("List all channels in our Slack workspace", markdown=True)
 
-# Example 3: Get the message history of a specific channel
-agent.print_response("Get the last 10 messages from the channel #random_junk", markdown=True)
+# Example 3: Get the message history of a specific channel by channel ID 
+agent.print_response("Get the last 10 messages from the channel 1231241", markdown=True)
 
 ```
 


### PR DESCRIPTION
slack get channel history needs channel ID, not channel name