### PR TITLE
Updating model name in groq.mdx 

### DIFF
--- a/models/groq.mdx
+++ b/models/groq.mdx
@@ -31,7 +31,7 @@ from phi.agent import Agent, RunResponse
 from phi.model.groq import Groq
 
 agent = Agent(
-    model=Groq(id="llama3-groq-70b-8192-tool-use-preview"),
+    model=Groq(id="llama-3.3-70b-versatile"),
     markdown=True
 )
 


### PR DESCRIPTION
Replacing model name to remove deprecated model (as of Jan 6th, 2025) and adding the proposed model 

Reference: https://console.groq.com/docs/deprecations#january-24-2025-llama-31-70b-and-llama-31-70b-speculative-decoding